### PR TITLE
terraformでAWSの環境構築 最低限

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,35 @@
+## Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/environment/dev/.terraform.lock.hcl
+++ b/terraform/environment/dev/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.95.0"
+  hashes = [
+    "h1:PUug/LLWa4GM08rXqnmCVUXj8ibCTvQxgvawhat3bMo=",
+    "zh:20aac8c95edd444e659f235d19fa6af9b259c5a70fce19d400539ee88687e7d4",
+    "zh:29c55846fadd19dde0c5108f74d507c296d6c37cabdd466a96d3721a7c261743",
+    "zh:325fa5cb42d58c9203c279450863c49e534672f7101c067af465f9d7f4be3be5",
+    "zh:4f18c643584f7ba554399c0db3dd1c81629dfc2508a8777890f9f3b80b5213b7",
+    "zh:561e38e9cc6f0be5470c187ea8d51047c4133d9cb74cc1c364a9ebe41f40a06b",
+    "zh:6ec2cceed96ca5e47591ef11686614c663b05e112a814d24246a2739066577b6",
+    "zh:710a227c02b8a50f75a82a7f063d2416e85783e02ed91bb22cc12e7a8e11a3cf",
+    "zh:97a2f5e9bf4cf9a38274eddb7967e1cb4e5b04960c7da3603d9b1c15e18b8626",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf6bfb01fff8226d86c1b219d67cd96f37bb9312b17d00340e6ff00dda2dbe82",
+    "zh:cba74d606149cbaaa8dfb69f369f2496b851643a879adc24b11515fcece42b66",
+    "zh:d5a2c36739cab677a48f4856958c96be6f018ff0da50d233ca93a3a21aaceca1",
+    "zh:df5d1466144852fe5da4af0628db6f02b5186c59f683e5085705d9b90cacfbc0",
+    "zh:f82d96b45983b3c73b78dced9e344512b7a9adb06e8c1e3e4f422605efbb756d",
+    "zh:fb523f787077270059a8f3ab52c0fc56257c0b3a06f0219be247c8b15ff0ca2a",
+  ]
+}

--- a/terraform/environment/dev/main.tf
+++ b/terraform/environment/dev/main.tf
@@ -1,0 +1,43 @@
+# terraform {
+#   required_version = ">= 1.8.0"
+#   required_providers {
+#     aws = {
+#       source  = "hashicorp/aws"
+#       version = "~> 5.50"
+#     }
+#   }
+# }
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "dynamodb" {
+  source        = "../../module/dynamodb"
+  table_name    = var.table_name
+  hash_key      = "id"
+  hash_key_type = "S"
+  tags          = var.tags
+}
+
+module "lambda" {
+  source                = "../../module/lambda"
+  function_name         = "${var.env}-${var.lambda_function_name}"
+  handler               = "bootstrap"
+  runtime               = "provided.al2023"
+  filename              = var.lambda_zip_path # 先に zip 済みバイナリを配置
+  environment_variables = { TABLE_NAME = module.dynamodb.table_name }
+  dynamodb_stream_arn   = module.dynamodb.stream_arn
+  tags                  = var.tags
+  table_name            = module.dynamodb.table_name
+  aws_region            = var.aws_region
+}
+
+module "apigateway" {
+  source            = "../../module/apigateway"
+  lambda_arn        = module.lambda.arn
+  tags              = var.tags
+  stage_name        = var.env
+  lambda_name       = module.lambda.function_name
+  lambda_invoke_arn = module.lambda.invoke_arn
+}

--- a/terraform/environment/dev/variable.tf
+++ b/terraform/environment/dev/variable.tf
@@ -1,0 +1,74 @@
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "env" {
+  description = "環境名"
+  type        = string
+  default     = "dev"
+}
+
+variable "table_name" {
+  description = "DynamoDBテーブルの名前"
+  type        = string
+  default     = "AttendanceLog"
+}
+
+variable "hash_key" {
+  description = "DynamoDBのハッシュキー"
+  type        = string
+  default     = "id"
+}
+
+variable "hash_key_type" {
+  description = "ハッシュキーのタイプ（S, N, B）"
+  type        = string
+  default     = "S"
+}
+
+variable "lambda_function_name" {
+  description = "Lambda関数の名前"
+  type        = string
+  default     = "attendance-api-server"
+}
+
+variable "lambda_handler" {
+  description = "Lambda関数のハンドラー"
+  type        = string
+  default     = "bootstrap"
+}
+
+variable "lambda_runtime" {
+  description = "Lambda関数のランタイム"
+  type        = string
+  default     = "provided.al2023"
+}
+
+# variable "lambda_role_arn" {
+#   description = "Lambda関数に付与するIAMロールのARN"
+#   type        = string
+# }
+
+variable "lambda_zip_path" {
+  description = "Lambda関数のZIPパッケージパス"
+  type        = string
+  default     = "./bootstrap.zip"
+}
+
+variable "lambda_environment_variables" {
+  description = "Lambda関数の環境変数"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tags" {
+  description = "共通のタグ"
+  type        = map(string)
+  default = {
+    Environment = "dev"
+    Project     = "example"
+  }
+}
+

--- a/terraform/environment/prod/main.tf
+++ b/terraform/environment/prod/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+module "dynamodb" {
+  source        = "../../module/dynamodb"
+  table_name    = var.table_name
+  hash_key      = var.hash_key
+  hash_key_type = var.hash_key_type
+  tags          = var.tags
+}
+
+module "lambda" {
+  source                = "../../module/lambda"
+  function_name         = var.lambda_function_name
+  handler               = var.lambda_handler
+  runtime               = var.lambda_runtime
+  role_arn              = var.lambda_role_arn
+  filename              = var.lambda_filename
+  environment_variables = var.lambda_environment_variables
+  dynamodb_stream_arn   = module.dynamodb.stream_arn
+  tags                  = var.tags
+}

--- a/terraform/environment/prod/variable.tf
+++ b/terraform/environment/prod/variable.tf
@@ -1,0 +1,55 @@
+variable "aws_region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "table_name" {
+  type    = string
+  default = "my-table-prod"
+}
+
+variable "hash_key" {
+  type    = string
+  default = "id"
+}
+
+variable "hash_key_type" {
+  type    = string
+  default = "S"
+}
+
+variable "lambda_function_name" {
+  type    = string
+  default = "my-lambda-prod"
+}
+
+variable "lambda_handler" {
+  type    = string
+  default = "index.handler"
+}
+
+variable "lambda_runtime" {
+  type    = string
+  default = "nodejs14.x"
+}
+
+variable "lambda_role_arn" {
+  type = string
+}
+
+variable "lambda_filename" {
+  type = string
+}
+
+variable "lambda_environment_variables" {
+  type    = map(string)
+  default = {}
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {
+    Environment = "prod"
+    Project     = "example"
+  }
+}

--- a/terraform/module/apigateway/main.tf
+++ b/terraform/module/apigateway/main.tf
@@ -1,0 +1,63 @@
+# REST API本体
+resource "aws_api_gateway_rest_api" "this" {
+  name        = "attendance-api"
+  description = "Attendance REST API"
+}
+
+# Lambda Integration
+resource "aws_api_gateway_resource" "proxy" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "proxy" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.proxy.id
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "proxy" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.proxy.id
+  http_method             = aws_api_gateway_method.proxy.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_invoke_arn
+}
+
+# デプロイメント
+resource "aws_api_gateway_deployment" "this" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.this))
+  }
+  depends_on = [
+    aws_api_gateway_integration.proxy
+  ]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ステージ
+resource "aws_api_gateway_stage" "this" {
+  deployment_id = aws_api_gateway_deployment.this.id
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  stage_name    = var.stage_name
+}
+
+# LambdaにAPI Gatewayから呼び出す権限
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# 出力
+output "invoke_url" {
+  value = "${aws_api_gateway_rest_api.this.execution_arn}/${aws_api_gateway_stage.this.stage_name}"
+}

--- a/terraform/module/apigateway/variable.tf
+++ b/terraform/module/apigateway/variable.tf
@@ -1,0 +1,19 @@
+variable "region" {
+  description = "The AWS region for the resources."
+  type        = string
+  default     = "ap-northeast-1"  # Default region value, you can change this if needed
+}
+variable "lambda_arn" { type = string }
+variable "tags"       { type = map(string) }
+variable "stage_name" { 
+  description = "Lambda function name"
+  type        = string
+}
+
+variable "lambda_name" {
+  type = string
+}
+
+variable "lambda_invoke_arn" {
+  type = string
+}

--- a/terraform/module/dynamodb/main.tf
+++ b/terraform/module/dynamodb/main.tf
@@ -1,0 +1,14 @@
+resource "aws_dynamodb_table" "this" {
+  name           = var.table_name
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = var.hash_key
+  stream_enabled = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = var.hash_key
+    type = var.hash_key_type
+  }
+
+  tags = var.tags
+}

--- a/terraform/module/dynamodb/output.tf
+++ b/terraform/module/dynamodb/output.tf
@@ -1,0 +1,9 @@
+output "table_name" {
+  description = "DynamoDBテーブルの名前"
+  value       = aws_dynamodb_table.this.name
+}
+
+output "stream_arn" {
+  description = "DynamoDBストリームのARN"
+  value       = aws_dynamodb_table.this.stream_arn
+}

--- a/terraform/module/dynamodb/variable.tf
+++ b/terraform/module/dynamodb/variable.tf
@@ -1,0 +1,20 @@
+variable "table_name" {
+  description = "DynamoDBテーブルの名前"
+  type        = string
+}
+
+variable "hash_key" {
+  description = "ハッシュキーの名前"
+  type        = string
+}
+
+variable "hash_key_type" {
+  description = "ハッシュキーのタイプ（S, N, B）"
+  type        = string
+}
+
+variable "tags" {
+  description = "リソースに適用するタグ"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/module/lambda/main.tf
+++ b/terraform/module/lambda/main.tf
@@ -1,0 +1,105 @@
+# AWSアカウントIDを取得（DynamoDBリソース指定用）
+data "aws_caller_identity" "current" {}
+
+# LambdaにアタッチするIAMロール作成
+resource "aws_iam_role" "lambda_exec" {
+  name               = "${var.function_name}-role"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+# IAMロールのAssumeRoleポリシードキュメント
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# Lambda関数本体
+resource "aws_lambda_function" "this" {
+  function_name    = var.function_name
+  handler          = var.handler
+  runtime          = var.runtime
+  role             = aws_iam_role.lambda_exec.arn
+  filename         = var.filename
+  source_code_hash = filebase64sha256(var.filename)
+
+  environment {
+    variables = var.environment_variables
+  }
+
+  tags = var.tags
+}
+
+# CloudWatchロググループ（Lambdaのログ保存先）
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${aws_lambda_function.this.function_name}"
+  retention_in_days = 14
+}
+
+# LambdaがCloudWatchログ出力できるための基本ポリシー付与
+resource "aws_iam_role_policy_attachment" "basic_logging" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# DynamoDBストリーム → Lambdaのイベントマッピング
+resource "aws_lambda_event_source_mapping" "dynamodb" {
+  event_source_arn  = var.dynamodb_stream_arn
+  function_name     = aws_lambda_function.this.arn
+  starting_position = "LATEST"
+}
+
+# DynamoDBストリーム読み取り権限ポリシー
+data "aws_iam_policy_document" "stream_access" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+      "dynamodb:DescribeStream",
+      "dynamodb:ListStreams"
+    ]
+    resources = [var.dynamodb_stream_arn]
+  }
+}
+
+resource "aws_iam_policy" "dynamodb_stream_access" {
+  name   = "${var.function_name}-ddb-stream-access"
+  policy = data.aws_iam_policy_document.stream_access.json
+}
+
+# 上記のストリーム権限をIAMロールにアタッチ
+resource "aws_iam_role_policy_attachment" "stream_access" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.dynamodb_stream_access.arn
+}
+
+# DynamoDB PutItem/UpdateItem 書き込み権限ポリシー
+data "aws_iam_policy_document" "dynamodb_write_access" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem"
+    ]
+    resources = [
+      "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${var.table_name}"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dynamodb_access" {
+  name   = "${var.function_name}-ddb-write-access"
+  policy = data.aws_iam_policy_document.dynamodb_write_access.json
+}
+
+# 上記の書き込み権限をIAMロールにアタッチ
+resource "aws_iam_role_policy_attachment" "dynamodb_write_access" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.dynamodb_access.arn
+}

--- a/terraform/module/lambda/output.tf
+++ b/terraform/module/lambda/output.tf
@@ -1,0 +1,18 @@
+output "invoke_arn" {
+  description = "Invoke ARN of the Lambda function"
+  value       = aws_lambda_function.this.invoke_arn
+}
+
+output "arn" {
+  description = "Lambda ARN (resource ARN)"
+  value       = aws_lambda_function.this.arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for the Lambda"
+  value       = aws_cloudwatch_log_group.lambda.name
+}
+output "function_name" {
+  description = "Lambda function name"
+  value       = aws_lambda_function.this.function_name
+}

--- a/terraform/module/lambda/variable.tf
+++ b/terraform/module/lambda/variable.tf
@@ -1,0 +1,17 @@
+variable "function_name"         { type = string }
+variable "handler"               { type = string }
+variable "runtime"               { type = string }
+variable "filename"              { type = string }
+variable "environment_variables" { type = map(string) }
+variable "dynamodb_stream_arn"   { type = string }
+variable "tags"                  { type = map(string) }
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "table_name" {
+  description = "DynamoDB table name"
+  type        = string
+}


### PR DESCRIPTION
# 概要
AWSのインフラをterraformで構築する

# やったこと
terraformを使ったlambda,apigateway,dynamodbの構築をおこないました。

## lambda
go のアプリをzipでデプロイするようにしています。
## apigateway
lambdaを動かすためのトリガー
## dynamodb
AttendanceLogという名前のテーブルを作成
# 構成
```
.
├── environment
│   ├── dev
│   │   ├── main.tf
│   │   ├── terraform.tfstate
│   │   ├── terraform.tfstate.1745644447.backup
│   │   ├── terraform.tfstate.1745644448.backup
│   │   ├── terraform.tfstate.backup
│   │   └── variable.tf
│   └── prod
│       ├── bootstrap.zip
│       ├── main.tf
│       └── variable.tf
└── module
    ├── apigateway
    │   ├── main.tf
    │   └── variable.tf
    ├── dynamodb
    │   ├── main.tf
    │   ├── output.tf
    │   └── variable.tf
    └── lambda
        ├── main.tf
        ├── output.tf
        └── variable.tf

8 directories, 18 files

```