### PR TITLE
勤怠ログの編集・削除機能を追加

### DIFF
--- a/server/src/usecase/attendance_log.go
+++ b/server/src/usecase/attendance_log.go
@@ -77,7 +77,7 @@ func (r *Repository) GetAttendanceLogListByUserAndMonth(ctx context.Context, tea
 }
 
 func (r *Repository) UpdateAttendanceLog(ctx context.Context, id string, newTimestamp time.Time) (*domain.AttendanceLog, error) {
-	result, err := r.attendanceLogRepository.attendanceLogRepository.DBUpdateAttendanceLog(ctx, id, newTimestamp)
+	result, err := r.attendanceLogRepository.DBUpdateAttendanceLog(ctx, id, newTimestamp)
 	if err != nil {
 		return nil, err
 	}

--- a/server/src/usecase/attendance_log.go
+++ b/server/src/usecase/attendance_log.go
@@ -75,3 +75,21 @@ func (r *Repository) GetAttendanceLogListByUserAndMonth(ctx context.Context, tea
 
 	return result, nil
 }
+
+func (r *Repository) UpdateAttendanceLog(ctx context.Context, id string, newTimestamp time.Time) (*domain.AttendanceLog, error) {
+	result, err := r.attendanceLogRepository.attendanceLogRepository.DBUpdateAttendanceLog(ctx, id, newTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *Repository) DeleteAttendanceLog(ctx context.Context, id string) error {
+	err := r.attendanceLogRepository.attendanceLogRepository.DBDeleteAttendanceLog(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/src/usecase/attendance_log.go
+++ b/server/src/usecase/attendance_log.go
@@ -86,7 +86,7 @@ func (r *Repository) UpdateAttendanceLog(ctx context.Context, id string, newTime
 }
 
 func (r *Repository) DeleteAttendanceLog(ctx context.Context, id string) error {
-	err := r.attendanceLogRepository.attendanceLogRepository.DBDeleteAttendanceLog(ctx, id)
+	err := r.attendanceLogRepository.DBDeleteAttendanceLog(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/server/src/usecase/port/attendance_log_port.go
+++ b/server/src/usecase/port/attendance_log_port.go
@@ -12,6 +12,8 @@ type AttendanceLogInputPort interface {
 	AddAttendanceLogEnd(ctx context.Context, teamId, channelId, userId, action string) (*domain.AttendanceLog, error)
 	SubscribeWorkplace(ctx context.Context, teamId, channelId, userId, workplace string) (*domain.WorkplaceBindings, error)
 	GetAttendanceLogListByUserAndMonth(ctx context.Context, teamId, channelId, userId, year, month string) ([]domain.AttendanceLog, error)
+	UpdateAttendanceLog(ctx context.Context, id string, newTimestamp time.Time) (*domain.AttendanceLog, error)
+	DeleteAttendanceLog(ctx context.Context, id string) error
 }
 
 type AttendanceLogRepository interface {
@@ -19,4 +21,7 @@ type AttendanceLogRepository interface {
 	DBAddAttendanceLogEnd(ctx context.Context, id, teamId, channelId, userId, action string, timestamp time.Time) (*domain.AttendanceLog, error)
 	DBSubscribeWorkplace(ctx context.Context, id, teamId, channelId, userId, workplace string, createdAt time.Time) (*domain.WorkplaceBindings, error)
 	DBGetAttendanceLogListByUserAndMonth(ctx context.Context, teamId, channelId, userId, year, month string) ([]domain.AttendanceLog, error)
+	DBGetAttendanceLog(ctx context.Context, id string) (*domain.AttendanceLog, error)
+	DBUpdateAttendanceLog(ctx context.Context, id string, newTimestamp time.Time) (*domain.AttendanceLog, error)
+	DBDeleteAttendanceLog(ctx context.Context, id string) error
 }


### PR DESCRIPTION
### 概要

このプルリクエストは、Slackコマンドを介して勤怠ログを編集および削除する機能を追加し、それに伴うバックエンドのロジックを実装します。

主な変更点：
- 新しいSlackコマンド `/edit-attendance` と `/delete-attendance` を追加
- 勤怠ログの更新・削除を行うバックエンドロジックを実装
- 勤怠ログの表示フォーマットを改善し、レコードIDを表示

### 詳細な変更

#### 1. Slackコマンドの追加
- ユーザーがSlackから直接勤怠ログを更新・削除できるよう、`/edit-attendance` と `/delete-attendance` コマンドを追加しました。
- これらのコマンドは、入力値のバリデーションを行い、適切なユーザーフィードバックを返します。

#### 2. バックエンドロジックの修正
- `Infrastructure` レイヤーに `DBUpdateAttendanceLog` と `DBDeleteAttendanceLog` メソッドを実装し、DynamoDBでの勤怠ログの更新・削除を可能にしました。
- `Repository` レイヤーには、アプリケーションロジックから利用するための `UpdateAttendanceLog` と `DeleteAttendanceLog` メソッドを追加しました。
- `AttendanceLogInputPort` と `AttendanceLogRepository` インターフェースを更新し、これらの操作をサポートするようにしました。

#### 3. 勤怠ログ表示の改善
- ユーザーが新しいコマンドを利用する際に参照しやすくなるよう、`FormatAttendance` 関数を修正し、各勤怠レコード（出勤・退勤）にIDが表示されるようにしました。
- 勤怠時間を正確にマッチングさせるためのヘルパー関数 `parseTime` を追加しました。

---